### PR TITLE
Added Base option and Fixed filename casing issue

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -68,6 +68,14 @@ namespace KattisTableGenerator {
             }
         }
 
+        public string GetBase() {
+            foreach (string baseFile in configuration.Base) {
+                string baseReadMe = File.ReadAllText(baseFile);
+                return baseReadMe;
+            }
+            return File.ReadAllText("DEFAULT.md");
+        }
+
         private bool IsProperFormatGithubUrl (string url) {
             return Uri.IsWellFormedUriString (url, UriKind.Absolute) && Regex.IsMatch (url, @"^https://github.com/[^/]+/[^/]+(/|/tree/master/([^/]+/?)+)?$");
         }

--- a/DEFAULT.md
+++ b/DEFAULT.md
@@ -1,0 +1,3 @@
+# Kattis
+
+Some solutions may be outdated and could be revised.

--- a/Generator.cs
+++ b/Generator.cs
@@ -143,6 +143,7 @@ namespace KattisTableGenerator {
         }
 
         private void TryAdd (string url, string id, string ext) {
+            id = id.ToLower();
             if (!ValidExtensions.Contains (ext)) {
                 Logger.WriteLine ($"Unknown extension found: {ext}");
                 return;

--- a/Program.cs
+++ b/Program.cs
@@ -30,8 +30,9 @@ namespace KattisTableGenerator {
                 generator.ProcessConfig ();
                 using (StreamWriter file = new StreamWriter ("README.md", false, UnicodeEncoding.Default, 1 << 16)) {
                     Logger.WriteLine ("Writing to README.md");
-                    file.WriteLine ("# Kattis Solutions");
-                    file.WriteLine ("Some solutions may be outdated and could be revised.\n");
+                    file.WriteLine(config.GetBase());
+                    file.WriteLine("\n");
+                    file.WriteLine("## Kattis Solutions");
                     string table = generator.GetTableString ();
                     file.WriteLine (table);
                 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Initially the `config.json` should look like this:
     "Ignore": [],
     "Url": [],
     "Folders": [],
-    "Base:" []
+    "Base": []
 }
 ```
 The `Ignore` property is a String array that can be filled with the names of files, directories, or extensions that are to be ignored during the process. By default, the program ignores extensions not found in `extensions.json`, which can be modified by the user.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Initially the `config.json` should look like this:
 {
     "Ignore": [],
     "Url": [],
-    "Folders": []
+    "Folders": [],
+    "Base:" []
 }
 ```
 The `Ignore` property is a String array that can be filled with the names of files, directories, or extensions that are to be ignored during the process. By default, the program ignores extensions not found in `extensions.json`, which can be modified by the user.
@@ -23,6 +24,8 @@ The `Ignore` property is a String array that can be filled with the names of fil
 The `Url` property is a String array that can be filled with the GitHub urls of where your solutions are located. Urls that are not from github are ignored.  
 
 The `Folders` property is an Object array where each object should have the properties `BaseUrl` (String) and `Paths` (String array). This causes the program to search a given local directory on the user's computer and finds Kattis solutions to hyperlink it to a given GitHub url of where their solutions are uploaded. This gives better performance than the `Url` property as it does not require any online requests. Some important details are that `BaseUrl` must be a GitHub url of where your solutions are located online and `Paths` consists of existing directories on your local computer.
+
+The `Base` property is a String array that should be filled with a path to a markdown file specifying a *header* for the generated `README.md`. This markdown file should contain all information you'd like to display prior to the table appearing on your `README.md`. If this is property is left empty, a default header will be generated.
 
 ## Other Information/Limitations
 - The generated table will be in a file called `README.md`.
@@ -56,7 +59,8 @@ In the example below, all files and directories that are named `hello` will be i
                 "C:\\Kattis\\C#"
             ]
         }
-    ]
+    ],
+    "Base": ["C:\\Kattis\\BASE_README.md"]
 }
 ```
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "Ignore": [],
     "Url": [],
-    "Folders": []
+    "Folders": [],
+    "Base": []
 }

--- a/structs/Configuration.cs
+++ b/structs/Configuration.cs
@@ -3,11 +3,13 @@ namespace KattisTableGenerator {
         public string[] Ignore { get; set; }
         public string[] Url { get; set; }
         public Folder[] Folders { get; set; }
+        public string[] Base { get; set; }
 
         public Configuration () {
             Ignore = new string[0];
             Url = new string[0];
             Folders = new Folder[0];
+            Base = new string[0];
         }
     }
 }


### PR DESCRIPTION
- Fixed issue where certain filenames, such as `Ptice.py` would not be considered but `ptice.py` would
  - Problem because some programming languages have naming conventions and it was a simple fix
- Added option to include "base" to the generated `README`. This can be specified in `config.json`
  - Offers customization regarding the header for the generated `README.md` but also provides a default option (shown in `DEFAULT.md`) if this option is not desired
  - `DEFAULT.md` must be present in the new `.zip`